### PR TITLE
updated MacOS Installation Documentation for database and requirements

### DIFF
--- a/docs/installation/alt-python.rst
+++ b/docs/installation/alt-python.rst
@@ -93,3 +93,12 @@ If this is all correct, you can restart the services, and should be good to go!
 .. code-block:: bash
 
   sudo systemctl start openl2m
+
+
+MacOS Python Versions
+---------------------
+
+You may use brew to install other versions of Python on MacOS. If you frequently switch versions,
+you may be interested in pyenv_
+
+.. _pyenv:https://realpython.com/intro-to-pyenv/

--- a/docs/installation/database.rst
+++ b/docs/installation/database.rst
@@ -27,6 +27,17 @@ Please consult your distribution's documentation for assistance with any errors.
   sudo systemctl start postgresql
   sudo systemctl enable postgresql
 
+**Installation - MacOS**
+
+.. code-block:: bash
+
+  brew install postgresql
+  brew services start postgresql
+
+NOTE: DO NOT USE SUDO TO BREW INSTALL, IT WILL CAUSE PERMISSION ISSUES. If you experience this please refer here_, or the brew documentation_.
+
+.. _here: https://stackoverflow.com/questions/67688802/brew-postgresql-starts-but-process-is-not-running
+.. _documentation: https://docs.brew.sh/Installation
 **Verify Version**
 
 Verify you are running at least version 13:
@@ -46,6 +57,22 @@ NOTE: DO NOT USE THE PASSWORD FROM THE EXAMPLE:
 .. code-block:: bash
 
   sudo -u postgres psql
+  psql (16.4 ...)
+  Type "help" for help.
+  postgres=# CREATE DATABASE openl2m;
+  CREATE DATABASE
+  postgres=# CREATE USER openl2m WITH PASSWORD 'xxxxxxxxxxxx';
+  CREATE ROLE
+  postgres=# GRANT ALL PRIVILEGES ON DATABASE openl2m TO openl2m;
+  GRANT
+  postgres=# \q
+
+
+*MacOS*
+
+.. code-block:: bash
+
+  psql postgres
   psql (16.4 ...)
   Type "help" for help.
   postgres=# CREATE DATABASE openl2m;

--- a/docs/installation/openl2m.rst
+++ b/docs/installation/openl2m.rst
@@ -28,6 +28,14 @@ Begin by installing all system packages required by OpenL2M and its dependencies
 *For best performance, we recommend using Python v3.12 (Ubuntu 24.04), as it has significant improvements over v3.10*
 :doc:`See the Alternate Python Installation section for more. <alt-python>`
 
+**MacOS**
+
+.. code-block:: bash
+
+  brew install libxml2 libxslt libffi postgresql openssl zlib
+  brew install openldap cyrus-sasl net-snmp git curl
+  brew install python@3.10
+
 OpenL2M Install
 ---------------
 
@@ -37,6 +45,23 @@ First, create the user environment for OpenL2M:
 
   sudo adduser --system --group openl2m
 
+
+**MacOS**
+.. code-block:: bash
+  #create the user
+  sudo dscl . -create /Users/openl2m
+  sudo dscl . -create /Users/openl2m UserShell /usr/bin/false
+  sudo dscl . -create /Users/openl2m UniqueID 600
+  sudo dscl . -create /Users/openl2m PrimaryGroupID 600
+  sudo dscl . -create /Users/openl2m NFSHomeDirectory /var/empty
+
+  #create the group
+  sudo dscl . -create /Groups/openl2m
+  sudo dscl . -create /Groups/openl2m PrimaryGroupID 600
+  sudo dscl . -append /Groups/openl2m GroupMembership openl2m
+
+  #add openl2m to the group
+  sudo dscl . -append /Groups/openl2m GroupMembership openl2m
 
 Next, install OpenL2M. The easiest is cloning the main branch of its repository on GitHub.
 


### PR DESCRIPTION
Added documentation into the .rst files for MacOS:

- Python Versioning
    - Homebrew and [pyenv](https://realpython.com/intro-to-pyenv/) options
- Database installation
    - Postgres through Homebrew
- Other requirements
    - Requirements (Homebrew installation)
    - MacOS specific user and group creation for OpenL2m


Resolves #31 