### PR TITLE
Feat/cmd output copy download

### DIFF
--- a/openl2m/project-static/js/openl2m.js
+++ b/openl2m/project-static/js/openl2m.js
@@ -1,0 +1,46 @@
+/* OpenL2M project-wide JS utilities */
+
+function ol2mCopyText(text) {
+  // Clipboard API requires a secure context (HTTPS / localhost).
+  // Fall back to execCommand for plain HTTP dev access over an IP.
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+  var ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  try { document.execCommand('copy'); } finally { document.body.removeChild(ta); }
+  return Promise.resolve();
+}
+
+document.addEventListener('click', function (e) {
+  // Copy command output to clipboard
+  var copyBtn = e.target.closest('.ol2m-copy-btn');
+  if (copyBtn) {
+    var pre = copyBtn.closest('.card').querySelector('.ol2m-cmd-pre');
+    ol2mCopyText(pre.textContent.trim()).then(function () {
+      var icon = copyBtn.querySelector('i');
+      var orig = icon.className;
+      icon.className = 'fa-solid fa-check';
+      setTimeout(function () { icon.className = orig; }, 1500);
+    });
+    return;
+  }
+
+  // Download command output as a text file
+  var dlBtn = e.target.closest('.ol2m-download-btn');
+  if (dlBtn) {
+    var pre = dlBtn.closest('.card').querySelector('.ol2m-cmd-pre');
+    var name = (dlBtn.getAttribute('data-command') || 'output')
+                 .replace(/[^a-zA-Z0-9_\-]/g, '_').slice(0, 64);
+    var blob = new Blob([pre.textContent.trim()], { type: 'text/plain' });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = name + '.txt';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+});

--- a/openl2m/project-static/js/openl2m.js
+++ b/openl2m/project-static/js/openl2m.js
@@ -25,7 +25,11 @@ document.addEventListener('click', function (e) {
       var icon = copyBtn.querySelector('i');
       var orig = icon.className;
       icon.className = 'fa-solid fa-check';
-      setTimeout(function () { icon.className = orig; }, 1500);
+      copyBtn.classList.replace('btn-outline-secondary', 'btn-success');
+      setTimeout(function () {
+        icon.className = orig;
+        copyBtn.classList.replace('btn-success', 'btn-outline-secondary');
+      }, 1500);
     });
     return;
   }

--- a/openl2m/templates/_base.html
+++ b/openl2m/templates/_base.html
@@ -124,6 +124,7 @@
 
   {% block javascript %}{% endblock %}
   <script src="{% static 'bootstrap-5.3.8-dist/js/bootstrap.bundle.js' %}"></script>
+  <script src="{% static 'js/openl2m.js' %}"></script>
   <script>
     // New Bootstrap 5 tooltip activation:
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));

--- a/openl2m/templates/_tab_cmd_output.html
+++ b/openl2m/templates/_tab_cmd_output.html
@@ -19,10 +19,25 @@
 </div>
 {% else %}{# output OK #}
 <div class="card border-default">
-  <div class="card-header bg-default"><strong>Command: </strong>{{ cmd.command }}</div>
+  <div class="card-header bg-default d-flex justify-content-between align-items-center">
+    <span><strong>Command: </strong>{{ cmd.command }}</span>
+    {% if cmd.output %}
+    <div class="d-flex gap-2">
+      <button type="button" class="btn btn-sm btn-outline-secondary ol2m-copy-btn"
+              data-bs-toggle="tooltip" data-bs-title="Copy output to clipboard">
+        <i class="fa-solid fa-copy" aria-hidden="true"></i> Copy
+      </button>
+      <button type="button" class="btn btn-sm btn-outline-secondary ol2m-download-btn"
+              data-command="{{ cmd.command }}"
+              data-bs-toggle="tooltip" data-bs-title="Download output as text file">
+        <i class="fa-solid fa-download" aria-hidden="true"></i> Download
+      </button>
+    </div>
+    {% endif %}
+  </div>
   {% if cmd.output %}
     <div class="card-body">
-      <pre>{{ cmd.output }}</pre>
+      <pre class="ol2m-cmd-pre">{{ cmd.output }}</pre>
     </div>
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary

Adds **Copy** and **Download** actions to the command output card in `_tab_cmd_output.html`.

- **Copy**: Copies command output to the clipboard. Uses the Clipboard API when available, with an `execCommand` fallback for non-secure (HTTP) contexts. On success, the icon switches to a checkmark and briefly turns green as visual feedback.
- **Download**: Downloads the output as a `.txt` file, named after the executed command.

Buttons are only shown when output is present (hidden for empty or error states).

Closes #101

## Changes

- `openl2m/templates/_tab_cmd_output.html`
  - Adds Copy/Download buttons in a flex-aligned card header
  - Adds `ol2m-cmd-pre` class to `<pre>` for JS targeting

- `openl2m/project-static/js/openl2m.js`
  - Introduces a project-wide JS utility loaded via `_base.html`
  - Uses event delegation with `.closest()` (no inline JS)

- `openl2m/templates/_base.html`
  - Loads `openl2m.js` after the Bootstrap bundle

## Notes

- Uses `data-bs-toggle="tooltip"` per project Bootstrap conventions
- No inline JavaScript
- Implementation verified in this branch